### PR TITLE
[TEST] ExploreUseCase Test

### DIFF
--- a/FanFollow/FanFollow.xcodeproj/project.pbxproj
+++ b/FanFollow/FanFollow.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		3CAC3D832A52F6B7000DE463 /* PostRequestDirector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CAC3D822A52F6B7000DE463 /* PostRequestDirector.swift */; };
 		3CC1D49A2A61114200713FAF /* StubChatRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC1D4992A61114200713FAF /* StubChatRepository.swift */; };
 		3CC1D49C2A61161100713FAF /* AccessChatRoomUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC1D49B2A61161100713FAF /* AccessChatRoomUseCaseTests.swift */; };
+		3CC1D49E2A6134C000713FAF /* ExploreUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC1D49D2A6134C000713FAF /* ExploreUseCaseTests.swift */; };
 		3CEE006C2A5D13DD009EE562 /* AccessChatRoomUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CEE006B2A5D13DD009EE562 /* AccessChatRoomUseCase.swift */; };
 		3CFC16D32A57E97D00B16ADF /* LikeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFC16D22A57E97D00B16ADF /* LikeServiceTests.swift */; };
 		3CFC16D42A57EC3000B16ADF /* DefaultLikeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 183974652A52636B00F0101A /* DefaultLikeRepository.swift */; };
@@ -204,6 +205,7 @@
 		3CAC3D822A52F6B7000DE463 /* PostRequestDirector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRequestDirector.swift; sourceTree = "<group>"; };
 		3CC1D4992A61114200713FAF /* StubChatRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubChatRepository.swift; sourceTree = "<group>"; };
 		3CC1D49B2A61161100713FAF /* AccessChatRoomUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessChatRoomUseCaseTests.swift; sourceTree = "<group>"; };
+		3CC1D49D2A6134C000713FAF /* ExploreUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreUseCaseTests.swift; sourceTree = "<group>"; };
 		3CEE006B2A5D13DD009EE562 /* AccessChatRoomUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessChatRoomUseCase.swift; sourceTree = "<group>"; };
 		3CFC16D22A57E97D00B16ADF /* LikeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikeServiceTests.swift; sourceTree = "<group>"; };
 		3CFDF6BB2A5D513C00DE6109 /* ChatRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoom.swift; sourceTree = "<group>"; };
@@ -748,6 +750,7 @@
 				EB0260412A60D90B0015F3C9 /* FetchCreatorPostsUseCaseTests.swift */,
 				EB0260432A60DAC10015F3C9 /* FetchUserInformationUseCaseTests.swift */,
 				3CC1D49B2A61161100713FAF /* AccessChatRoomUseCaseTests.swift */,
+				3CC1D49D2A6134C000713FAF /* ExploreUseCaseTests.swift */,
 			);
 			path = UseCaseTests;
 			sourceTree = "<group>";
@@ -1069,6 +1072,7 @@
 				EBA8EB672A5FC0D500998630 /* FetchFeedUseCaseTests.swift in Sources */,
 				3CC1D49C2A61161100713FAF /* AccessChatRoomUseCaseTests.swift in Sources */,
 				EBA8EB692A5FC16800998630 /* StubPostRepository.swift in Sources */,
+				3CC1D49E2A6134C000713FAF /* ExploreUseCaseTests.swift in Sources */,
 				3CC1D49A2A61114200713FAF /* StubChatRepository.swift in Sources */,
 				EB0260422A60D90B0015F3C9 /* FetchCreatorPostsUseCaseTests.swift in Sources */,
 				EB0260442A60DAC10015F3C9 /* FetchUserInformationUseCaseTests.swift in Sources */,

--- a/FanFollow/UseCaseTests/ExploreUseCaseTests.swift
+++ b/FanFollow/UseCaseTests/ExploreUseCaseTests.swift
@@ -1,0 +1,185 @@
+//
+//  ExploreUseCaseTests.swift
+//  UseCaseTests
+//
+//  Created by parkhyo on 2023/07/14.
+//
+
+import XCTest
+
+import RxSwift
+import RxTest
+import RxBlocking
+
+@testable import FanFollow
+
+final class ExploreUseCaseTests: XCTestCase {
+    private var exploreUseCase: ExploreUseCase!
+    private var userInformationRepository: StubUserInformationRepository!
+    private var error: Error!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        userInformationRepository = StubUserInformationRepository()
+        exploreUseCase = DefaultExploreUseCase(userInformationRepository: userInformationRepository)
+    }
+    
+    override func tearDownWithError() throws {
+        error = nil
+        userInformationRepository = nil
+        exploreUseCase = nil
+        try super.tearDownWithError()
+    }
+    
+    ////  RPC를 실행 없이 Repository에서 전달받은 Creator정보를 반환하는지 확인하는 테스트
+    func test_fetchRandomCreatorsIsCorrectWhenSendCorrectData() throws {
+        // given
+        userInformationRepository.error = nil
+        userInformationRepository.userInformations = UserInformationDTO.stubCreatorsData()
+        
+        // when
+        let randomCreatorsObservalble = exploreUseCase.fetchRandomCreators(jobCategory: .IT, count: 3)
+        
+        // then
+        let result = randomCreatorsObservalble.toBlocking()
+        
+        XCTAssertEqual(try? result.first()?.count, 3)
+        
+        switch result.materialize() {
+        case .completed:
+            XCTAssertTrue(true)
+        case .failed(_, let error):
+            XCTAssertThrowsError(error, "We expected Completed Event, But Occur Error Event")
+        }
+    }
+    
+    ////  RPC를 실행 없이 Repository에서 전달받은 카테고리 별 Creator정보를 반환하는지 확인하는 테스트
+    func test_fetchRandomAllCreatorsIsCorrectWhenSendCorrectData() throws {
+        // given
+        userInformationRepository.error = nil
+        userInformationRepository.userInformations = UserInformationDTO.stubCreatorsData()
+        
+        // when
+        let randomAllCreatorsObservalble = exploreUseCase.fetchRandomAllCreators(count: 10)
+        
+        // then
+        let result = randomAllCreatorsObservalble.toBlocking()
+        
+        XCTAssertEqual(try? result.first()?.count, JobCategory.allCases.count)
+        
+        switch result.materialize() {
+        case .completed:
+            XCTAssertTrue(true)
+        case .failed(_, let error):
+            XCTAssertThrowsError(error, "We expected Completed Event, But Occur Error Event")
+        }
+    }
+    
+    ////  RPC를 실행 없이 Repository에서 전달받은 Popular Creator정보를 반환하는지 확인하는 테스트
+    func test_fetchPopularCreatorsIsCorrectWhenSendCorrectData() throws {
+        // given
+        userInformationRepository.error = nil
+        userInformationRepository.userInformations = UserInformationDTO.stubCreatorsData()
+        
+        // when
+        let randomCreatorsObservalble = exploreUseCase.fetchPopularCreators(jobCategory: .IT, count: 1)
+        
+        // then
+        let result = randomCreatorsObservalble.toBlocking()
+        
+        XCTAssertEqual(try? result.first()?.count, 3)
+        
+        switch result.materialize() {
+        case .completed:
+            XCTAssertTrue(true)
+        case .failed(_, let error):
+            XCTAssertThrowsError(error, "We expected Completed Event, But Occur Error Event")
+        }
+    }
+    
+    ////  RPC를 실행 없이 Repository에서 전달받은 에러를 반환하는지 확인하는 테스트
+    func test_fetchRandomCreatorsIsErrorWhenSendCorrectData() throws {
+        // given
+        userInformationRepository.error = NetworkError.unknown
+        userInformationRepository.userInformations = UserInformationDTO.stubCreatorsData()
+        
+        // when
+        let randomCreatorsObservalble = exploreUseCase.fetchRandomCreators(jobCategory: .IT, count: 3)
+        
+        // then
+        let result =  randomCreatorsObservalble.toBlocking().materialize()
+        
+        switch result {
+        case .completed:
+            XCTAssertThrowsError(NetworkError.unknown, "We expected Error Event, But Occur OnCompleted Event")
+        case .failed:
+            XCTAssertTrue(true)
+        }
+    }
+}
+
+private extension UserInformationDTO {
+    static func stubCreatorData() -> Self {
+        return UserInformationDTO(
+            userID: "UserTestID",
+            nickName: "CreatorTestNickName",
+            profilePath: "CreatorTestProfileTest",
+            jobCategory: JobCategory.IT.rawValue,
+            links: [],
+            introduce: "CreatorTestIntroduce",
+            isCreator: true,
+            createdAt: "CreatorTestDate"
+        )
+    }
+    
+    static func stubCreatorsData() -> [Self] {
+        return [
+            UserInformationDTO(
+                userID: "UserTestID",
+                nickName: "CreatorTestNickName",
+                profilePath: "CreatorTestProfileTest",
+                jobCategory: JobCategory.IT.rawValue,
+                links: [],
+                introduce: "CreatorTestIntroduce",
+                isCreator: true,
+                createdAt: "CreatorTestDate"
+            ),
+            
+            UserInformationDTO(
+                userID: "UserTestID2",
+                nickName: "CreatorTestNickName",
+                profilePath: "CreatorTestProfileTest",
+                jobCategory: JobCategory.IT.rawValue,
+                links: [],
+                introduce: "CreatorTestIntroduce",
+                isCreator: true,
+                createdAt: "CreatorTestDate"
+            ),
+            
+            UserInformationDTO(
+                userID: "UserTestID3",
+                nickName: "CreatorTestNickName",
+                profilePath: "CreatorTestProfileTest",
+                jobCategory: JobCategory.art.rawValue,
+                links: [],
+                introduce: "CreatorTestIntroduce",
+                isCreator: true,
+                createdAt: "CreatorTestDate"
+            ),
+        ]
+    }
+    
+    
+    static func stubFanData() -> Self {
+        return UserInformationDTO(
+            userID: "UserTestID",
+            nickName: "FanTestNickName",
+            profilePath: "FanTestProfileTest",
+            jobCategory: nil,
+            links: nil,
+            introduce: nil,
+            isCreator: false,
+            createdAt: "FanTestDate"
+        )
+    }
+}


### PR DESCRIPTION
## What is this PR? 🔎
- ExploreUseCase Test 코드 작성

## Changes 📄
- ExploreUseCase Test 코드 작성
- ExploreUseCase  `fetchRandomAllCreators()` 반환 값 Observable 튜플 로 변경

## ScreenShots 📸

|TestCoverage|
|:---:|
| <img width="1278" alt="Coverage" src="https://github.com/Young-Child/FanFollow/assets/59204352/2c5be4cc-7998-405c-ab49-15920cb65694"> |

## To Reviewers 💌
- Creator 정보를 Remote ProcedureCall로 필터링해서 가져오기 때문에 오류 발생안했을 경우 정상 값 반환하는지, StubData 갯수가 일치하는지에 대한 비교만 진행하였습니다.
- [x] fetchRandomCreators() Test
- [x] fetchRandomAllCreators() Test
- [x] fetchPopularCreators Test
