### PR TITLE
[FEATURE] ExploreView 내부에서 ProfileFeedView로 이동 구현

### DIFF
--- a/FanFollow/FanFollow/Source/Coordinator/ExploreCoordinator.swift
+++ b/FanFollow/FanFollow/Source/Coordinator/ExploreCoordinator.swift
@@ -13,6 +13,10 @@ class ExploreCoordinator: Coordinator {
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
     
+    // User Property
+    //TODO: - 추후 주입 어떻게 해야할지 논의 필요
+    private let userID: String
+    
     // Dependency
     private let userInformationRepository: UserInformationRepository
     private let exploreUseCase: ExploreUseCase
@@ -20,6 +24,7 @@ class ExploreCoordinator: Coordinator {
     
     init(navigationController: UINavigationController) {
         self.navigationController = navigationController
+        self.userID = "5b587434-438c-49d8-ae3c-88bb27a891d4"
         
         userInformationRepository = DefaultUserInformationRepository(DefaultNetworkService())
         exploreUseCase = DefaultExploreUseCase(userInformationRepository: userInformationRepository)
@@ -40,8 +45,34 @@ class ExploreCoordinator: Coordinator {
         navigationController.pushViewController(controller, animated: true)
     }
     
-    func presentProfileViewController(to userID: String) {
-        // TODO: - Profile 이동 구현
+    func presentProfileViewController(to creatorID: String) {
+        let networkService = DefaultNetworkService()
+
+        let postRepository = DefaultPostRepository(networkService: networkService)
+        let fetchCreatorPostsUseCase = DefaultFetchCreatorPostsUseCase(postRepository: postRepository)
+
+        let userInformationRepository = DefaultUserInformationRepository(networkService)
+        let followRepository = DefaultFollowRepository(networkService)
+        let fetchCreatorInformationUseCase = DefaultFetchCreatorInformationUseCase(
+            userInformationRepository: userInformationRepository,
+            followRepository: followRepository
+        )
+
+        let likeRepository = DefaultLikeRepository(networkService: networkService)
+        let changeLikeUseCase = DefaultChangeLikeUseCase(likeRepository: likeRepository)
+
+        
+        let viewModel = ProfileFeedViewModel(
+            fetchCreatorPostUseCase: fetchCreatorPostsUseCase,
+            fetchCreatorInformationUseCase: fetchCreatorInformationUseCase,
+            changeLikeUseCase: changeLikeUseCase,
+            creatorID: creatorID,
+            userID: userID
+        )
+        
+        let controller = ProfileFeedViewController(viewModel: viewModel, viewType: .profileFeed)
+        
+        navigationController.pushViewController(controller, animated: true)
     }
     
     func presentSearchViewController() {

--- a/FanFollow/FanFollow/Source/Coordinator/ExploreCoordinator.swift
+++ b/FanFollow/FanFollow/Source/Coordinator/ExploreCoordinator.swift
@@ -72,6 +72,7 @@ class ExploreCoordinator: Coordinator {
         
         let controller = ProfileFeedViewController(viewModel: viewModel, viewType: .profileFeed)
         
+        navigationController.setNavigationBarHidden(false, animated: false)
         navigationController.pushViewController(controller, animated: true)
     }
     

--- a/FanFollow/FanFollow/Source/Coordinator/SettingScene/SettingCoodinator.swift
+++ b/FanFollow/FanFollow/Source/Coordinator/SettingScene/SettingCoodinator.swift
@@ -27,6 +27,10 @@ class SettingCoordinator: Coordinator {
         childCoordinators.append(coordinator)
         coordinator.start()
     }
+    
+    func presentPostBottomViewController() {
+        //TODO: - 추후 구현
+    }
 }
 
 private extension SettingCoordinator {

--- a/FanFollow/FanFollow/Source/Presenter/Comman/UI/Controller/ExploreTabBarController.swift
+++ b/FanFollow/FanFollow/Source/Presenter/Comman/UI/Controller/ExploreTabBarController.swift
@@ -27,13 +27,17 @@ final class ExploreTabBarController: TopTabBarController<ExploreTapItem> {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        setCoordinator()
+        setExplorCoordinator()
     }
     
-    private func setCoordinator() {
-        guard let controller = viewControllers?.first as? ExploreViewController else { return }
-        
-        controller.coordinator = self.coordinator
+    private func setExplorCoordinator() {
+        viewControllers?.forEach({ viewController in
+            if let controller = viewController as? ExploreViewController {
+                controller.coordinator = self.coordinator
+            } else if let controller = viewController as? ExploreSubscribeViewController {
+                controller.coordinator = self.coordinator
+            }
+        })
     }
 }
 

--- a/FanFollow/FanFollow/Source/Presenter/Comman/UI/Controller/SettingTabBarController.swift
+++ b/FanFollow/FanFollow/Source/Presenter/Comman/UI/Controller/SettingTabBarController.swift
@@ -5,6 +5,7 @@
 //  Copyright (c) 2023 Minii All rights reserved.
 
 import UIKit
+import RxSwift
 
 protocol SettingTabBarDelegate: AnyObject {
     func settingController(_ controller: SettingViewController, removeFeedManageTab isCreator: Bool)
@@ -12,10 +13,20 @@ protocol SettingTabBarDelegate: AnyObject {
 }
 
 final class SettingTabBarController: TopTabBarController<SettingTabItem> {
+    private let postButton = UIButton().then {
+        $0.setImage(UIImage(systemName: "plus"), for: .normal)
+        $0.tintColor = .label
+        $0.backgroundColor = .clear
+    }
+    
     weak var coordinator: SettingCoordinator?
+    private var disposeBag = DisposeBag()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        configureUI()
+        bindPostButton()
         setDelegate()
     }
     
@@ -47,5 +58,35 @@ extension SettingTabBarController: SettingTabBarDelegate {
     
     func settingController(_ controller: SettingViewController, didTapPresent item: SettingSectionItem) {
         coordinator?.presentSettingDetailController(to: item.presentType)
+    }
+}
+
+// Binding
+private extension SettingTabBarController {
+    func bindPostButton() {
+        postButton.rx.tap
+            .bind { _ in
+                self.coordinator?.presentPostBottomViewController()
+            }
+            .disposed(by: disposeBag)
+    }
+}
+
+// Configure UI
+private extension SettingTabBarController {
+    func configureUI() {
+        configureHierarchy()
+        makeConstraints()
+    }
+    
+    func configureHierarchy() {
+        view.addSubview(postButton)
+    }
+    
+    func makeConstraints() {
+        postButton.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(10)
+            $0.trailing.equalToSuperview().offset(-20)
+        }
     }
 }

--- a/FanFollow/FanFollow/Source/Presenter/ExploreScene/ExploreCategoryScene/View/ExploreCategoryViewController.swift
+++ b/FanFollow/FanFollow/Source/Presenter/ExploreScene/ExploreCategoryScene/View/ExploreCategoryViewController.swift
@@ -70,6 +70,18 @@ extension ExploreCategoryViewController {
             .asDriver(onErrorJustReturn: [])
             .drive(exploreCategoryCollectionView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)
+        
+        exploreCategoryCollectionView.rx.modelSelected(ExploreSectionItem.self)
+            .throttle(.seconds(1), scheduler: MainScheduler.instance)
+            .bind { item in
+                switch item {
+                case .creator(_, let creatorID):
+                    self.coordinator?.presentProfileViewController(to: creatorID)
+                default:
+                    break
+                }
+            }
+            .disposed(by: disposeBag)
     }
     
     func bindingInput() -> ExploreCategoryViewModel.Output {

--- a/FanFollow/FanFollow/Source/Presenter/ExploreScene/ExploreMainScene/ViewModel/ExploreViewModel.swift
+++ b/FanFollow/FanFollow/Source/Presenter/ExploreScene/ExploreMainScene/ViewModel/ExploreViewModel.swift
@@ -10,7 +10,6 @@ import RxSwift
 final class ExploreViewModel: ViewModel {
     struct Input {
         var viewWillAppear: Observable<Void>
-        var cellDidSelected: Observable<ExploreSectionItem>
     }
     
     struct Output {
@@ -42,20 +41,6 @@ final class ExploreViewModel: ViewModel {
         ) { categories, recommand in
             return categories + recommand
         }
-        
-        // About viewByJopCategory Input
-        input.cellDidSelected
-            .subscribe { sectionItem in
-                switch sectionItem.element {
-                case .category(let job):
-                    print("JOB:", job)
-                case .creator(let nickName, let userID):
-                    print("CREATOR:", nickName, userID)
-                default:
-                    break
-                }
-            }
-            .disposed(by: disposeBag)
         
         return Output(exploreSectionModel: exploreSectionModel)
     }

--- a/FanFollow/FanFollow/Source/Presenter/ExploreScene/ExploreSearchScene/View/ExploreSearchViewController.swift
+++ b/FanFollow/FanFollow/Source/Presenter/ExploreScene/ExploreSearchScene/View/ExploreSearchViewController.swift
@@ -68,6 +68,12 @@ final class ExploreSearchViewController: UIViewController {
         configureUI()
         binding()
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        navigationController?.setNavigationBarHidden(true, animated: true)
+    }
 }
 
 // Binding

--- a/FanFollow/FanFollow/Source/Presenter/ExploreScene/ExploreSearchScene/View/ExploreSearchViewController.swift
+++ b/FanFollow/FanFollow/Source/Presenter/ExploreScene/ExploreSearchScene/View/ExploreSearchViewController.swift
@@ -120,6 +120,13 @@ extension ExploreSearchViewController: UISearchBarDelegate {
             }
             .drive(self.searchLabel.rx.isHidden)
             .disposed(by: disposeBag)
+        
+        searchTableView.rx.modelSelected(Creator.self)
+            .throttle(.seconds(1), scheduler: MainScheduler.instance)
+            .bind { item in
+                self.coordinator?.presentProfileViewController(to: item.id)
+            }
+            .disposed(by: disposeBag)
     }
     
     func bindingInput() -> ExploreSearchViewModel.Output {

--- a/FanFollow/FanFollow/Source/Presenter/ExploreScene/ExploreSubscribeScene/View/ExploreSubscribeViewController.swift
+++ b/FanFollow/FanFollow/Source/Presenter/ExploreScene/ExploreSubscribeScene/View/ExploreSubscribeViewController.swift
@@ -83,6 +83,13 @@ extension ExploreSubscribeViewController {
                 cell.configureCell(creator: data)
             }
             .disposed(by: disposeBag)
+        
+        subscribeTableView.rx.modelSelected(Creator.self)
+            .throttle(.seconds(1), scheduler: MainScheduler.instance)
+            .bind { item in
+                self.coordinator?.presentProfileViewController(to: item.id)
+            }
+            .disposed(by: disposeBag)
     }
 }
 


### PR DESCRIPTION
## What is this PR? 🔎
- ExploreView 내부에서 ProfileFeedView로 이동 구현

## Changes 📄
- ExploreCategoryView 내부에서 CreatorCell Tab할 경우 ProfileFeedView로 이동 구현
- ExploreCategoryView 내부에서 CreatorListCell Tab할 경우 ProfileFeedView로 이동 구현
- ExploreSearchView 내부에서 CreatorListCell Tab할 경우 ProfileFeedView로 이동 구현
- ExploreSubscribeView 내부에서 CreatorListCell Tab할 경우 ProfileFeedView로 이동 구현

## To Reviewers 💌
- ExploreView 초기 생성시 UserID 임의로 주입
- Navigation Bar BackButton 안보이는 문제로 임의로 Coordinator메서드 및 각 View의 ViewWillAppear에서 Navigation Hidden 처리
- ViewModel에서 Cell 탭이벤트에 직접 적으로 관여하지 않고 View에서 TableView, CollectionView와 자체적으로 Binding하여 View이동 구현하였습니다.